### PR TITLE
update notebook for 2023

### DIFF
--- a/data/Leeds_LE2023_results.csv
+++ b/data/Leeds_LE2023_results.csv
@@ -1,0 +1,176 @@
+Candidate,Description,Votes,Electorate,Turnout,Spoilt ballots,Ward,vote_share
+CLAPCOTE Steve,Labour and Co-operative Party,2064,16606,43.0,28,Adel & Wharfedale,29.3
+FLYNN Billy,The Conservative Party Candidate,3087,16606,43.0,28,Adel & Wharfedale,43.8
+LOVE Fiona Sarah Heather,Green Party,554,16606,43.0,28,Adel & Wharfedale,7.9
+SLINGER Sharon Margaret,Liberal Democrats,1343,16606,43.0,28,Adel & Wharfedale,19.1
+BUCKLEY Lyn Jean,The Conservative Party Candidate,3253,17522,37.0,15,Alwoodley,49.8
+DEWS Howard Graham,Yorkshire Party,164,17522,37.0,15,Alwoodley,2.5
+ELLIS Jackie,Labour Party,2350,17522,37.0,15,Alwoodley,36.0
+JENNINGS Louise Mary,Green Party,340,17522,37.0,15,Alwoodley,5.2
+LEVY Jonathan Jared,Liberal Democrats,419,17522,37.0,15,Alwoodley,6.4
+HOLROYD-CASE Stephen,Labour and Co-operative Party,2284,17762,30.0,35,Ardsley & Robin Hood,43.8
+LEADLEY Tom,Liberal Democrats,1338,17762,30.0,35,Ardsley & Robin Hood,25.7
+SURYAWANSHI Lalit Raghunath,The Conservative Party Candidate,1237,17762,30.0,35,Ardsley & Robin Hood,23.7
+WHETSTONE Daniel Paul,Social Democratic Party,101,17762,30.0,35,Ardsley & Robin Hood,1.9
+ZADOK Leon,Green Party,254,17762,30.0,35,Ardsley & Robin Hood,4.9
+CUNNINGHAM Lou,Green Party,1712,17343,25.0,15,Armley,39.8
+KOVACS Tamas,The Conservative Party Candidate,419,17343,25.0,15,Armley,9.7
+MCDONALD Edana Niamh,Yorkshire Party,129,17343,25.0,15,Armley,3.0
+MILLER Jim,Independent,39,17343,25.0,15,Armley,0.9
+PARNHAM Andy,Labour Party,1897,17343,25.0,15,Armley,44.1
+WALKER Dan,Liberal Democrats,105,17343,25.0,15,Armley,2.4
+ANDREWS Peter Richard,Liberal Democrats,209,18712,21.0,30,Beeston & Holbeck,5.3
+AZEEM Muhammad,The Conservative Party Candidate,450,18712,21.0,30,Beeston & Holbeck,11.3
+GWYTHER Katherine Alice,Trade Unionist and Socialist Coalition,44,18712,21.0,30,Beeston & Holbeck,1.1
+PERRY Nigel,Social Democratic Party,107,18712,21.0,30,Beeston & Holbeck,2.7
+POLUCCIU Mariana,Green Party,662,18712,21.0,30,Beeston & Holbeck,16.7
+SCOPES Andrew Timothy,Labour Party,2494,18712,21.0,30,Beeston & Holbeck,62.9
+BEE Elizabeth Anne,Liberal Democrats,479,17176,25.0,36,Bramley & Stanningley,11.2
+COOK Adam Daniel,The Conservative Party Candidate,696,17176,25.0,36,Bramley & Stanningley,16.3
+HINCHCLIFFE Tom,Labour Party,2662,17176,25.0,36,Bramley & Stanningley,62.2
+RILEY Richard David,Social Democratic Party,62,17176,25.0,36,Bramley & Stanningley,1.4
+WHITTAKER Keith Duncan,Green Party,384,17176,25.0,36,Bramley & Stanningley,9.0
+ADEYEMI Taiwo Funmilayo,The Conservative Party Candidate,294,17023,22.0,21,Burmantofts & Richmond Hill,7.8
+CHAVES-SANDERSON Richard,Trade Unionist and Socialist Coalition,88,17023,22.0,21,Burmantofts & Richmond Hill,2.3
+HOLLINGSWORTH David Ewan,Liberal Democrats,392,17023,22.0,21,Burmantofts & Richmond Hill,10.3
+MANAKA Nkele Charmaine,Labour Party,2547,17023,22.0,21,Burmantofts & Richmond Hill,67.2
+SHARAZUR Rebwar Raouf,Green Party,410,17023,22.0,21,Burmantofts & Richmond Hill,10.8
+WHETSTONE Paul Anthony,Social Democratic Party,59,17023,22.0,21,Burmantofts & Richmond Hill,1.6
+CARLILL Peter John,Labour and Co-operative Party,3926,18466,39.0,18,Calverley & Farsley,54.8
+GRAHAM Ellen,Green Party,251,18466,39.0,18,Calverley & Farsley,3.5
+LEES Rob,Yorkshire Party,250,18466,39.0,18,Calverley & Farsley,3.5
+MCLEOD Stuart,Liberal Democrats,205,18466,39.0,18,Calverley & Farsley,2.9
+SINGH Jas,The Conservative Party Candidate,2536,18466,39.0,18,Calverley & Farsley,35.4
+AHAD Safaraz,The Conservative Party Candidate,390,18455,33.0,41,Chapel Allerton,6.4
+CHOUDHRY Aqila,Liberal Democrats,246,18455,33.0,41,Chapel Allerton,4.0
+DAVIES Mike,Alliance for Green Socialism,183,18455,33.0,41,Chapel Allerton,3.0
+DOWSON Jane Alice,Labour and Co-operative Party,4505,18455,33.0,41,Chapel Allerton,73.9
+WALKER Bobak,Green Party,721,18455,33.0,41,Chapel Allerton,11.8
+WATSON Sasha Samantha Holdsworth,Social Democratic Party,48,18455,33.0,41,Chapel Allerton,0.8
+COOPER Patricia,Liberal Democrats,233,18287,29.0,17,Cross Gates & Whinmoor,4.4
+HEMINGWAY Martin Francis,Green Party,302,18287,29.0,17,Cross Gates & Whinmoor,5.7
+KENNEDY John,The Conservative Party Candidate,1557,18287,29.0,17,Cross Gates & Whinmoor,29.6
+LENNOX Jess,Labour Party,2823,18287,29.0,17,Cross Gates & Whinmoor,53.7
+NICHOLSON Mark,Independent,339,18287,29.0,17,Cross Gates & Whinmoor,6.5
+ARMITAGE Natalia Justyna,The Conservative Party Candidate,538,18214,27.0,17,Farnley & Wortley,10.8
+BELLFIELD Jack Michael,Social Democratic Party,17,18214,27.0,17,Farnley & Wortley,0.3
+GOLTON Christine Mavis,Liberal Democrats,65,18214,27.0,17,Farnley & Wortley,1.3
+LOCKWOOD Bev,Independent,61,18214,27.0,17,Farnley & Wortley,1.2
+MCCLUSKEY Adrian,Labour Party,2438,18214,27.0,17,Farnley & Wortley,49.1
+ROLLINSON Mark Terence,Green Party,1648,18214,27.0,17,Farnley & Wortley,33.2
+WHITEHEAD Andrea,Reform UK,201,18214,27.0,17,Farnley & Wortley,4.0
+BEER Stephen Paul,Green Party,384,16205,39.0,19,Garforth & Swillington,6.1
+BENTLEY Peter James,Local Conservatives,912,16205,39.0,19,Garforth & Swillington,14.4
+KNOX Jake,Liberal Democrats,195,16205,39.0,19,Garforth & Swillington,3.1
+MCCORMACK Suzanne Jane,Garforth and Swillington Independents Party,3428,16205,39.0,19,Garforth & Swillington,54.2
+MURROW Luke Anthony,Labour Party,1257,16205,39.0,19,Garforth & Swillington,19.9
+WILSON-KERR Tyler Callum,Independent,152,16205,39.0,19,Garforth & Swillington,2.4
+ALI Asghar,Labour Party,2655,17961,26.0,25,Gipton & Harehills,56.2
+ALI Mothin Mohammed,Green Party,1484,17961,26.0,25,Gipton & Harehills,31.4
+DALTON Iain Alaistair,Trade Unionist and Socialist Coalition,121,17961,26.0,25,Gipton & Harehills,2.6
+HARRIS Robert David Winston,The Conservative Party Candidate,310,17961,26.0,25,Gipton & Harehills,6.6
+TWITCHETT Mark John,Liberal Democrats,156,17961,26.0,25,Gipton & Harehills,3.3
+BUXTON Bob,Yorkshire Party,591,18611,42.0,16,Guiseley & Rawdon,7.5
+EDWARDS Oliver Roland,Labour and Co-operative Party,3678,18611,42.0,16,Guiseley & Rawdon,46.9
+JACQUES Robert Hugh,Liberal Democrats,293,18611,42.0,16,Guiseley & Rawdon,3.7
+WADSWORTH Paul John Spencer,Local Conservatives,2934,18611,42.0,16,Guiseley & Rawdon,37.4
+WHEELER Lucy Katherine,Green Party,345,18611,42.0,16,Guiseley & Rawdon,4.4
+COOK Dan,Liberal Democrats,406,14942,42.0,17,Harewood,6.5
+EVANS Claire Anne,Green Party,627,14942,42.0,17,Harewood,10.1
+GILL Oliver,Labour Party,1459,14942,42.0,17,Harewood,23.5
+STEPHENSON Ryan,Local Conservatives,3708,14942,42.0,17,Harewood,59.8
+ASHFORD Brandon John,Liberal Democrats,145,23783,18.0,16,Headingley & Hyde Park,3.5
+GOODALL Tim,Green Party,1749,23783,18.0,16,Headingley & Hyde Park,42.0
+GREAUX Anthony Joseph,Independent,27,23783,18.0,16,Headingley & Hyde Park,0.6
+HANNAN Abdul,Labour Party,2029,23783,18.0,16,Headingley & Hyde Park,48.7
+HYNAM Florian Oscar Alice,Trade Unionist and Socialist Coalition,48,23783,18.0,16,Headingley & Hyde Park,1.2
+MARTIN Andrew Stuart,Local Conservatives,119,23783,18.0,16,Headingley & Hyde Park,2.9
+TINDLE Molly,Northern Independence Party - Nationalise Energy Companies,52,23783,18.0,16,Headingley & Hyde Park,1.2
+COWLING Ian,Yorkshire Party,241,17917,42.0,31,Horsforth,3.2
+JONES Raymond Wyn,Labour Party,3810,17917,42.0,31,Horsforth,51.4
+SHAW Ian William,Green Party,581,17917,42.0,31,Horsforth,7.8
+SHEMILT Jackie,Local Conservatives,2302,17917,42.0,31,Horsforth,31.0
+SPENCER James Michael,Liberal Democrats,483,17917,42.0,31,Horsforth,6.5
+DUNCAN Oisín Conor,Trade Unionist and Socialist Coalition,27,17795,24.0,31,Hunslet & Riverside,0.6
+FOSTER Thomas Peter,Social Democratic Party,48,17795,24.0,31,Hunslet & Riverside,1.1
+MUSHTAQ Mohammed Omar,Green Party,1809,17795,24.0,31,Hunslet & Riverside,42.1
+RUTHERFORD Owen Scott,The Conservative Party Candidate,231,17795,24.0,31,Hunslet & Riverside,5.4
+TURNER-CHASTNEY Benedict Luke,Liberal Democrats,89,17795,24.0,31,Hunslet & Riverside,2.1
+WRAY Paul Ian,Labour and Co-operative Party,2095,17795,24.0,31,Hunslet & Riverside,48.7
+ANTHONEY David Alan,Green Party,369,18297,21.0,28,Killingbeck & Seacroft,9.7
+CHANDLER Bradley Kenneth,The Conservative Party Candidate,676,18297,21.0,28,Killingbeck & Seacroft,17.9
+DYE Katie,Labour Party,2446,18297,21.0,28,Killingbeck & Seacroft,64.6
+OTLEY John,Liberal Democrats,295,18297,21.0,28,Killingbeck & Seacroft,7.8
+MARTIN Alan Terry,Green Party,406,17509,30.0,31,Kippax & Methley,7.8
+MCINTEE Lesley Ann,Liberal Democrats,301,17509,30.0,31,Kippax & Methley,5.8
+MILLAR Michael Thomas,Labour Party,3163,17509,30.0,31,Kippax & Methley,60.5
+MULHALL Connor Joseph Paul,Local Conservatives,1362,17509,30.0,31,Kippax & Methley,26.0
+BELCHER Adam James,Liberal Democrats,288,16138,29.0,29,Kirkstall,6.1
+CAPITANO Reiss Lewis,The Conservative Party Candidate,402,16138,29.0,29,Kirkstall,8.6
+LONG Stuart William,Independent,95,16138,29.0,29,Kirkstall,2.0
+RONTREE Andy,Labour Party,3018,16138,29.0,29,Kirkstall,64.4
+SMITH Victoria Helen,Green Party,886,16138,29.0,29,Kirkstall,18.9
+ARBUCKLE Katherine Mary,Liberal Democrats,163,16301,18.0,15,Little London & Woodhouse,5.7
+BRACUTI Anthony Joseph,Trade Unionist and Socialist Coalition,96,16301,18.0,15,Little London & Woodhouse,3.4
+LALVANI Nick,Green Party,437,16301,18.0,15,Little London & Woodhouse,15.3
+MARSHALL KATUNG Abigail,Labour and Co-operative Party,1908,16301,18.0,15,Little London & Woodhouse,66.6
+RAJA Muhammad Sajjad,The Conservative Party Candidate,261,16301,18.0,15,Little London & Woodhouse,9.1
+ADEYEMI Samson Roberts,The Conservative Party Candidate,376,20215,21.0,9,Middleton Park,8.7
+AGBEMAFLE Eunice Delali,Green Party,186,20215,21.0,9,Middleton Park,4.3
+ARBUCKLE Jude Patrick,Liberal Democrats,86,20215,21.0,9,Middleton Park,2.0
+DONALDSON Joelle Darnelle,Trade Unionist and Socialist Coalition,91,20215,21.0,9,Middleton Park,2.1
+POGSON-GOLDEN Emma Louise,Social Democratic Party,1985,20215,21.0,9,Middleton Park,46.0
+SUMMERS Lauren Alice,Labour and Co-operative Party,1587,20215,21.0,9,Middleton Park,36.8
+FARMER Lee Anthony,The Conservative Party Candidate,1210,17363,39.0,25,Moortown,17.7
+HARTSHORNE Rachel,Green Party,892,17363,39.0,25,Moortown,13.1
+SHAHZAD Mohammed,Labour and Co-operative Party,3938,17363,39.0,25,Moortown,57.7
+STEPHENS David William,Yorkshire Party,226,17363,39.0,25,Moortown,3.3
+SYKES George,Liberal Democrats,557,17363,39.0,25,Moortown,8.2
+COWLES Richard Thomas,Social Democratic Party,25,18282,31.0,11,Morley North,0.4
+DAVEY Patrick Gerard,Labour and Co-operative Party,1400,18282,31.0,11,Morley North,25.0
+EATWELL Dom,The Conservative Party Candidate,848,18282,31.0,11,Morley North,15.1
+FINNIGAN Robert,Morley Borough Independents,2448,18282,31.0,11,Morley North,43.6
+KELLETT Rebecca Sofia,Green Party,313,18282,31.0,11,Morley North,5.6
+THACKRAY Johnathan Robert,Reform UK,252,18282,31.0,11,Morley North,4.5
+TRUEMAN James,Liberal Democrats,323,18282,31.0,11,Morley North,5.8
+BARTICEL Mihai Marcelin,Liberal Democrats,191,18284,28.0,27,Morley South,3.8
+BELL Chris,Green Party,450,18284,28.0,27,Morley South,8.9
+BRADLEY Bailey Jacob Statton,Labour Party,1510,18284,28.0,27,Morley South,30.0
+GEORGE Charles Henry Jack,The Conservative Party Candidate,749,18284,28.0,27,Morley South,14.9
+KIDGER Wyn,Morley Borough Independents,2094,18284,28.0,27,Morley South,41.6
+MARTIN Andrew Alexander,Social Democratic Party,41,18284,28.0,27,Morley South,0.8
+BRADLEY Mick,Green Party,946,18283,38.0,31,Otley & Yeadon,13.5
+BUXTON Claire Jane,Yorkshire Party,197,18283,38.0,31,Otley & Yeadon,2.8
+DOWNES Ryk,Liberal Democrats,3189,18283,38.0,31,Otley & Yeadon,45.5
+HARPER Stewart Peter,Local Conservatives,791,18283,38.0,31,Otley & Yeadon,11.3
+MCCARGO Ian Joseph,Labour and Co-operative Party,1727,18283,38.0,31,Otley & Yeadon,24.7
+NATHAN Elliot Edwards,Breakthrough Party,156,18283,38.0,31,Otley & Yeadon,2.2
+AHMED Riaz,Labour Party,2891,19116,36.0,27,Pudsey,41.9
+GLOVER Christine Amy,Liberal Democrats,352,19116,36.0,27,Pudsey,5.1
+HALL Alaric Timothy Peter,Green Party,398,19116,36.0,27,Pudsey,5.8
+KELLY Tom,Reform UK,201,19116,36.0,27,Pudsey,2.9
+SMITH Trish,Local Conservatives,3050,19116,36.0,27,Pudsey,44.3
+CHAPMAN Diane,Liberal Democrats,3409,15821,35.0,16,Rothwell,61.6
+DRIVER James Louis,Labour and Co-operative Party,1200,15821,35.0,16,Rothwell,21.7
+GBOLADE Babatunde Abiodun,Local Conservatives,372,15821,35.0,16,Rothwell,6.7
+MCDONALD Sean Francis,Yorkshire Party,274,15821,35.0,16,Rothwell,4.9
+MOORSOM Tim,Green Party,260,15821,35.0,16,Rothwell,4.7
+WELBOURNE Sarah Jane,Social Democratic Party,21,15821,35.0,16,Rothwell,0.4
+AHAD Shazar,The Conservative Party Candidate,992,17684,38.0,35,Roundhay,14.8
+BOWDEN Jordan Daniel,Labour and Co-operative Party,3758,17684,38.0,35,Roundhay,56.0
+ELLIS Paul Charles,Green Party,1475,17684,38.0,35,Roundhay,22.0
+FINLAY Darren,Liberal Democrats,482,17684,38.0,35,Roundhay,7.2
+NORMAN Keith Cecil,Liberal Democrats,376,16730,30.0,30,Temple Newsam,7.4
+SHARPE Nicole Louise,Labour Party,2632,16730,30.0,30,Temple Newsam,52.1
+TRIGG Cormac John,The Conservative Party Candidate,1647,16730,30.0,30,Temple Newsam,32.6
+TURVER Geraldine Mary,Green Party,331,16730,30.0,30,Temple Newsam,6.6
+WHETSTONE Wendy Vivienne,Social Democratic Party,61,16730,30.0,30,Temple Newsam,1.2
+BASU Angelo,Local Conservatives,411,15776,42.0,12,Weetwood,6.2
+FOREN Christopher Mark,Green Party,550,15776,42.0,12,Weetwood,8.3
+HESELWOOD Jools,Labour and Co-operative Party,3103,15776,42.0,12,Weetwood,46.7
+HOWLEY Chris,Liberal Democrats,2534,15776,42.0,12,Weetwood,38.1
+WALKER Rob,Social Democratic Party,47,15776,42.0,12,Weetwood,0.7
+NUTTGENS Lucy Kathleen,Labour and Co-operative Party,498,16730,46.0,18,Wetherby,6.5
+PRINCE James Andrew,Liberal Democrats,161,16730,46.0,18,Wetherby,2.1
+RICHARDS Linda Judith,Local Conservatives,2958,16730,46.0,18,Wetherby,38.4
+STABLES Penny,Green Party,4079,16730,46.0,18,Wetherby,53.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,12 @@ channels:
 dependencies:
   - python=3.8
   - pandas=1.4.2
-  - selenium=4.1.0
   - beautifulsoup4=4.11.1
   - jupyterlab=3.4.0
   - lxml=4.8.0
   - ca-certificates
   - certifi
   - openssl
+  - pip=23
+  - pip:
+      - selenium==4.9.1

--- a/notebooks/Leeds_LE2022_scraper.ipynb
+++ b/notebooks/Leeds_LE2022_scraper.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,11 +23,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# since 2021 Leeds city council has listed results on a single page on their website\n",
+    "# since 2022 Leeds city council has listed results on a single page on their website\n",
     "# we set the address as a variable below\n",
     "\n",
     "main_page = 'https://www.leeds.gov.uk/your-council/elections/leeds-city-council-election-results'"
@@ -35,18 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/dh/dnx6pt7d3mb4l_fs2phsjg640000gn/T/ipykernel_41251/1316070037.py:7: DeprecationWarning: executable_path has been deprecated, please pass in a Service object\n",
-      "  wd = webdriver.Chrome('../tools/chromedriver', options=options)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# set up selenium to use chrome in headless state\n",
     "# this opens the page using chrome in a selenium session\n",
@@ -54,8 +45,8 @@
     "from selenium.webdriver.chrome.options import Options\n",
     "\n",
     "options = Options()\n",
-    "options.headless = True\n",
-    "wd = webdriver.Chrome('../tools/chromedriver', options=options)\n",
+    "options.add_argument(\"--headless=new\")\n",
+    "wd = webdriver.Chrome(options=options)\n",
     "\n",
     "wd.get(main_page)\n",
     "\n",
@@ -64,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -82,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,23 +147,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_frame.to_csv(\"../data/Leeds_LE2022_results.csv\", index=False)"
+    "# close the webdriver\n",
+    "wd.close()"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_frame.to_csv(\"../data/Leeds_LE2023_results.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
This PR updates the main notebook to fetch data for 2023.

It already introduces non backwards compatible changes:
- Removes selenium from conda and installs via pip upgrading to selenium4
- Changes code around selenium to meet selenium4 API